### PR TITLE
fix: husky pre-commit에서 empty new line때문에 생기는 버그 수정

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-
 yarn lint
 yarn test


### PR DESCRIPTION
## Description

- 커밋시 git console에서 ` env: sh\r: No such file or directory ` 에러가 발생하는 문제 발견
- pre-commit에서 empty new line 삭제 후 해결

## What type of PR is this?

- [x] 🐛 Bug Fix

## Related Tickets & Documents

[Ticket: WOO-93](https://linear.app/woody-yoonkee/issue/WOO-93/[0]-husky-pre-commit에서-empty-new-line으로-인한-버그-수정)