### PR TITLE
chore: ESLint의 import/prefer-default-export 설정 OFF

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -27,6 +27,7 @@ module.exports = {
         namedComponents: 'arrow-function',
       },
     ],
+    'import/prefer-default-export': 'off',
   },
   ignorePatterns: ['node_modules/', 'dist/'],
 };


### PR DESCRIPTION
## Description

- ESLint의 import/prefer-default-export를 off로 설정하였습니다.

## What type of PR is this?

- [x] 📦 Chore (Release)

## Related Tickets & Documents

[Ticket: WOO-97](https://linear.app/woody-yoonkee/issue/WOO-97/[0]-eslint-importprefer-default-export-설정-off)
