### PR TITLE
chore: ESLint 옵션 추가

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -28,6 +28,12 @@ module.exports = {
       },
     ],
     'import/prefer-default-export': 'off',
+    'react/jsx-sort-props': 1,
+    '@typescript-eslint/member-ordering': [
+      1,
+      { default: { memberTypes: ['signature', 'method', 'constructor', 'field'], order: 'alphabetically' } },
+    ],
+    'react/jsx-props-no-spreading': 'off',
   },
   ignorePatterns: ['node_modules/', 'dist/'],
 };


### PR DESCRIPTION
## Description

react/jsx-sort-props : component로 넘겨주는 props와 JSX Element의 속성을 정렬하는 옵션입니다.

@typescript-eslint/member-ordering : 타입의 속성들을 정렬하는 옵션입니다.

react/jsx-props-no-spreading : 컴포넌트에서 spreading props를 억제하는 옵션을 off합니다.

## What type of PR is this?

- [x] 📦 Chore (Release)

## Related Tickets & Document

Ticket: toss-order #26 
